### PR TITLE
Invalidate cart if it contains deleted items

### DIFF
--- a/web/src/context/siteContext.tsx
+++ b/web/src/context/siteContext.tsx
@@ -101,6 +101,14 @@ const StoreContextProvider = ({ children }: { children: any }) => {
         if (existingCheckoutId) {
           try {
             const checkout = await fetchCheckout(store, existingCheckoutId)
+            
+            // Make sure none of the items in this cart have been deleted from Shopify.
+            if (checkout.lineItems.some((lineItem) => !lineItem.variant)) {
+              throw new Error(
+                'Invalid line item in checkout. This variant was probably deleted from Shopify',
+              )
+            }
+            
             // Make sure this cart hasn’t already been purchased.
             console.log('sup checkout?', checkout)
             if (!checkout.completedAt) {


### PR DESCRIPTION
This PR adds an additional check after fetching an existing cart to make sure that no variants are `null`. I believe this can happen if a cart contains line item(s) that have been deleted from Shopify since they were originally added.

To test:

1. Add a product to the cart
2. Go into Shopify and delete that product
3. Refresh the page and a new cart should be created
