### PR TITLE
Removing JSON.stringify for payload and metapayload on axios requests

### DIFF
--- a/web/src/lambda/shopify-sync.ts
+++ b/web/src/lambda/shopify-sync.ts
@@ -72,7 +72,7 @@ const updateEverything = async (data: {
     url: `https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2020-10/graphql.json`,
     method: 'POST',
     headers: shopifyConfig,
-    data: JSON.stringify(metaPayLoad)
+    data: metaPayLoad
   })
 
   try {
@@ -213,7 +213,7 @@ export const handler = async (event: APIGatewayEvent): Promise<any> => {
         url: `https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2020-10/graphql.json`,
         method: 'POST',
         headers: shopifyConfig,
-        data: JSON.stringify(payload)
+        data: payload
       })
 
       const {


### PR DESCRIPTION
![doubleEscapedProductQuery](https://user-images.githubusercontent.com/45669613/107328213-a8931f80-6aae-11eb-9cb5-48fee33070dd.png)

Preventing escaped escapes for the moment to make sync functional again.